### PR TITLE
ci: add GitHub Pages deploy workflow (non-safe build for custom _plugins)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,72 @@
+name: Deploy Jekyll site to Pages
+
+# Runs a full (non-safe) Jekyll build so the custom plugins under _plugins/
+# (jekyll-paginate-authors.rb, jekyll-paginate-tags.rb) are executed, then
+# publishes the result via the official Pages deployment action.
+#
+# Requires repo Settings -> Pages -> Source: "GitHub Actions".
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+# Minimum permissions required by actions/deploy-pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment; cancel in-progress runs but let a
+# currently deploying run finish so the Pages site is never left broken.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    # Only run on the upstream botbie/blog repo; skip on forks.
+    if: github.repository == 'botbie/blog'
+    runs-on: ubuntu-latest
+    env:
+      JEKYLL_ENV: production
+      BUNDLE_WITHOUT: development
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Match the Ruby version the existing Gemfile.lock was resolved against
+      # (see Dockerfile: FROM ruby:2.6). Bundler 1.13.6 in BUNDLED WITH is too
+      # old to be installed on modern rubygems, so we pin the last 1.x release
+      # compatible with Ruby 2.6.
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+          bundler: '1.17.3'
+          bundler-cache: true
+
+      - name: Configure Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./_site
+
+  deploy:
+    if: github.repository == 'botbie/blog'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pages.yml` — a GitHub Actions workflow that builds the site with a full (non-safe) `bundle exec jekyll build` and publishes via `actions/deploy-pages`.
- Fixes missing `/author/<name>/` and `/tag/<name>/` pages on deploy: both URL trees are generated by local Ruby plugins (`_plugins/jekyll-paginate-authors.rb`, `_plugins/jekyll-paginate-tags.rb`) which the default `jekyll-build-pages` action disables because it runs in safe mode.
- No changes to site source, layouts, `_config.yml`, or the plugins themselves.

## Why

The default GitHub Pages builder loads only whitelisted gems and ignores everything under `_plugins/`. Under that builder these two generators never run, so every per-author and per-tag page 404s in production despite rendering fine locally (`bundle exec jekyll serve`) and in the Docker dev environment.

Switching to a custom Actions workflow is the lowest-friction fix: no code changes, no gem swaps, no URL-structure regressions.

## What the workflow does

- **Trigger:** push to `master` + manual `workflow_dispatch`.
- **build job**
  - `actions/checkout@v4`
  - `ruby/setup-ruby@v1` with `ruby-version: '2.6'` (matches `Dockerfile`) and `bundler: '1.17.3'` (the last Bundler 1.x compatible with Ruby 2.6; `Gemfile.lock`'s `BUNDLED WITH 1.13.6` is too old for modern rubygems).
  - `bundler-cache: true` for dependency caching.
  - `BUNDLE_WITHOUT: development` skips the `neovim` dev gem in CI.
  - `actions/configure-pages@v5` to resolve the base path.
  - `bundle exec jekyll build` with `JEKYLL_ENV: production` — **no `--safe`**, so the custom plugins execute.
  - `actions/upload-pages-artifact@v3` from `./_site`.
- **deploy job**
  - `needs: build`, environment `github-pages`.
  - `actions/deploy-pages@v4`.
- **Permissions:** minimum required (`contents:read`, `pages:write`, `id-token:write`).
- **Concurrency:** single-flight on the `pages` group, non-cancelling.
- **Fork safety:** both jobs guarded with `if: github.repository == 'botbie/blog'` so the workflow is a no-op on forks and PR checks here.

## One-time setup required after merge

In the repo settings: **Settings → Pages → Source: GitHub Actions** (replaces "Deploy from branch"). Without this, `deploy-pages` has nowhere to publish.

## Verification plan

After merge and the Source change:
1. Workflow appears in the Actions tab and completes green.
2. `https://blog.botbie.io/` (the `CNAME`) continues to serve the home page.
3. `/author/<username>/` for any user in `_data/authors.yml` renders the author layout — currently 404.
4. `/tag/<some-tag>/` for any tag used in `_posts/*` renders the tag layout — currently 404.

## Follow-ups (out of scope, worth flagging)

- Ruby 2.6 is EOL. After this workflow is green, a separate PR could bump Jekyll 3.8 → 4.x and Ruby to 3.3. The two custom plugins use stable `Jekyll::Page` / `Paginate::Pager` APIs and should port with minor-to-no changes (or a swap to `jekyll-paginate-v2`).
- Bundler 1.13.6 pin in `Gemfile.lock` is effectively abandoned; worth regenerating the lockfile once Ruby is bumped.