### PR TITLE
fix(plugin): merge case-variant tags into a single archive page

### DIFF
--- a/_plugins/jekyll-paginate-tags.rb
+++ b/_plugins/jekyll-paginate-tags.rb
@@ -84,14 +84,31 @@ module Jekyll
 
         # Generate paginated pages if necessary.
         #
+        # Tags whose names differ only in case or in characters that the slug
+        # function strips (e.g. "ctf" and "CTF", "WebAssembly" and "webassembly")
+        # are merged onto a single page — otherwise both generate to the same
+        # /tag/<slug>/ path and one silently overwrites the other, dropping the
+        # posts of the losing tag from the archive.
+        #
         # site - The Site.
         #
         # Returns nothing.
         def generate(site)
-          if site.config['paginate_tag_basepath']
-            for tag in site.tags.keys
-              paginate_tag(site, tag)
-            end
+          return unless site.config['paginate_tag_basepath']
+
+          tags_payload = site.site_payload['site']['tags']
+          groups = {}
+
+          tags_payload.each do |tag_name, posts|
+            slug = slugify_tag(tag_name)
+            next if slug.empty?
+            bucket = (groups[slug] ||= { names: [], posts: [] })
+            bucket[:names] << tag_name
+            bucket[:posts].concat(posts)
+          end
+
+          groups.each do |slug, bucket|
+            paginate_tag(site, canonical_name(bucket[:names]), slug, dedup(bucket[:posts]))
           end
         end
 
@@ -99,17 +116,15 @@ module Jekyll
         # directories (see paginate_tag_basepath and paginate_path config) for these tags,
         # e.g.: /tags/my-tag/page2/index.html, /tags/my-tag/page3/index.html, etc.
         #
-        # site     - The Site.
-        # tag - The tag to paginate.
+        # site      - The Site.
+        # tag       - Display name to expose to the layout as `page.tag`.
+        # slug      - URL slug, used to build the output directory.
+        # all_posts - Ordered list of post payloads to paginate.
         #
         # Returns nothing.
-        def paginate_tag(site, tag)
-          # Retrieve posts from that specific tag.
-          all_posts = site.site_payload['site']['tags'][tag]
-
+        def paginate_tag(site, tag, slug, all_posts)
           # Tag base path
-          tag_path = site.config['paginate_tag_basepath']
-          tag_path = tag_path.sub(':name', tag.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, ''))
+          tag_path = site.config['paginate_tag_basepath'].sub(':name', slug)
 
           # Count pages
           nb_pages = Pager.calculate_pages(all_posts, site.config['paginate'].to_i)
@@ -126,6 +141,39 @@ module Jekyll
             newpage.dir = Pager.paginate_path_tag(site, current_num_page, tag_path)
             site.pages << newpage
           end
+        end
+
+        private
+
+        # Slugify a tag name the same way URLs are built. Must stay in sync
+        # with the default Jekyll `slugify` Liquid filter used in the
+        # pagination partials so generated paths and rendered links match.
+        def slugify_tag(tag)
+          tag.to_s.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')
+        end
+
+        # Pick a canonical display name for a group of colliding tag strings.
+        # Preference order: exact all-lowercase variant (matches the URL slug
+        # visually), otherwise the first name encountered.
+        def canonical_name(names)
+          names.find { |n| n == n.downcase } || names.first
+        end
+
+        # Remove duplicate post payloads (a post tagged with both "CTF" and
+        # "ctf" would otherwise appear twice on the merged page), then sort
+        # newest-first to preserve archive ordering.
+        def dedup(posts)
+          seen = {}
+          unique = posts.reject do |post|
+            key = post['url'] || post.object_id
+            if seen[key]
+              true
+            else
+              seen[key] = true
+              false
+            end
+          end
+          unique.sort_by { |post| post['date'] || Time.at(0) }.reverse
         end
       end
 


### PR DESCRIPTION
## Summary

- `_plugins/jekyll-paginate-tags.rb` slugifies tag names via `tag.downcase.strip.gsub(' ', '-').gsub(/[^\w-]/, '')`, so distinct tag strings that share a slug (e.g. `CTF` + `ctf`, `WebAssembly` + `webassembly`) target the same `/tag/<slug>/` destination.
- The old generator iterated `site.tags.keys` and emitted one page per tag name, so two tag names that slugified identically produced two pages at the same path. Jekyll logged `Conflict: The following destination is shared by multiple files` and the second page silently overwrote the first — dropping the posts of the losing tag from the archive.
- This PR groups tag names by slug before generation, unions + dedups their posts, and renders one page per slug.

## Concrete example from the current post set

Three posts carry either `ctf` or `CTF`:

| Post | Tag(s) |
|---|---|
| `_posts/2012-12-31-29c3-ctf-misc-300-funchive.md` | `ctf` |
| `_posts/2014-07-01-binary-analysis-next-chapter-of-the-game.md` | `ctf` |
| `_posts/2018-10-14--flareon2018-chal5-webassembly-writeup-side-channel-attack.md` | `CTF` |

Before: `/tag/ctf/` listed either two posts or one, depending on hash iteration order, and the build logged a conflict warning. After: `/tag/ctf/` lists all three in reverse-chronological order.

## Implementation notes

- **Grouping** happens on `site.site_payload['site']['tags']` (the same Liquid-drop array the old code passed to `Pager.new`), so pagination, templating and `paginator.posts` keep their existing shape.
- **Dedup** by `post['url']` protects against a post tagged with multiple case variants appearing twice on the merged page. Order is re-established via `sort_by { |p| p['date'] }.reverse`.
- **Display name** (`page.tag` in the layout) picks the first all-lowercase variant among the grouped names, falling back to the first seen. This matches the URL slug visually and keeps the rendered page headers readable.
- **Empty slugs skipped**: a tag whose characters are entirely stripped by the slug function would otherwise emit a page at `/tag//`. `next if slug.empty?` removes that edge case.
- `_plugins/jekyll-paginate-authors.rb` is not affected — authors are keyed by unique `authors.yml` usernames, not by free-form tag strings, so the collision pattern doesn't arise there.

## Validation

Local `bundle exec jekyll build` (Jekyll 4.4.1) with the fix:

- Build completes in ~3s with no `Conflict` warnings.
- 56 `_site/tag/<slug>/` directories produced.
- `_site/tag/ctf/index.html` contains links to all three CTF posts (verified with grep).
- `_site/tag/bitcoin/page/{2,3}/` pagination still works for high-volume tags.
- All non-colliding tags (`bitcoin`, `blockchain`, `cryptocurrency`, etc.) render identically to before.

## Relation to #87

This is the follow-up the Ruby/Jekyll upgrade PR (#87) flagged. Logically independent and applies cleanly on top of current `master`. Either order of review/merge works; the upgrade PR does not modify this plugin.